### PR TITLE
Fix out of bounds access converting to dictionary

### DIFF
--- a/coreFoundation/dictionary.go
+++ b/coreFoundation/dictionary.go
@@ -64,8 +64,8 @@ func ToCFDictionary(dictionary interface{}) (DictionaryRef, error) {
 			return 0, errors.Wrap(err, "convert value for CFDictionaryRef")
 		}
 
-		keys[i] = key
-		values[i] = value
+		keys = append(keys, key)
+		values = append(values, value)
 	}
 
 	return (DictionaryRef)(C.CFDictionaryCreate(


### PR DESCRIPTION
When converting to a dictionary the keys and values lists are initialised with appropriate capacity, but 0 length, so assigning using `[i]` does not work and we need to use `append` instead.